### PR TITLE
Added case for downloading FAA NASR under Windows (MINGW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ You will need to run these scripts in this order to download dependencies, initi
 1. [bootstrap](./script/README.md#scriptbootstrap)
 2. [setup](./script/README.md#scriptsetup)
 
+### MINGW Requirements
+
+To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (i.e., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH.
+
+Additionally, xpath is needed. Once Perl is installed, xpath may be downloaded with cpan:
+
+```bash
+cpan Scalar::Util
+cpan XML::XPath
+```
 ### MATLAB MEX
 
 Compile the [MEX functions](https://www.mathworks.com/help/matlab/call-mex-file-functions.html) detailed in the [MATLAB directory README](./matlab/README.md).

--- a/README.md
+++ b/README.md
@@ -31,16 +31,8 @@ You can confirm `AEM_DIR_CORE` was set in unix by inspecting the output of `env`
 
 ### MINGW Requirements
 
-To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (e.g., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH.
-
-Additionally, xpath is needed. Once Perl is installed, xpath may be downloaded with cpan:
-
-```bash
-cpan Scalar::Util
-cpan XML::XPath
-```
-
-This step must be done before running the setup script when using MINGW.
+To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (e.g., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH. This step must be done before running the setup script when using MINGW. 
+The bootstrap.sh script will install xpath and Scalar::Util using Perl's cpan tool.
 
 ### Scripts
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ export AEM_DIR_CORE=PATH TO /em-core
 
 You can confirm `AEM_DIR_CORE` was set in unix by inspecting the output of `env`.
 
+### MINGW Requirements
+
+To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (e.g., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH.
+
+Additionally, xpath is needed. Once Perl is installed, xpath may be downloaded with cpan:
+
+```bash
+cpan Scalar::Util
+cpan XML::XPath
+```
+
+This step must be done before running the setup script when using MINGW.
+
 ### Scripts
 
 This is a set of boilerplate scripts describing the [normalized script pattern that GitHub uses in its projects](https://github.blog/2015-06-30-scripts-to-rule-them-all/). The [GitHub Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all) was used as a template. Refer to the [script directory README](./script/README.md) for more details.
@@ -38,16 +51,6 @@ You will need to run these scripts in this order to download dependencies, initi
 1. [bootstrap](./script/README.md#scriptbootstrap)
 2. [setup](./script/README.md#scriptsetup)
 
-### MINGW Requirements
-
-To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (i.e., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH.
-
-Additionally, xpath is needed. Once Perl is installed, xpath may be downloaded with cpan:
-
-```bash
-cpan Scalar::Util
-cpan XML::XPath
-```
 ### MATLAB MEX
 
 Compile the [MEX functions](https://www.mathworks.com/help/matlab/call-mex-file-functions.html) detailed in the [MATLAB directory README](./matlab/README.md).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Software and data used by multiple repositories in the [Aerospace Encounter Mode
 - [em-core](#em-core)
   - [Initial Setup](#initial-setup)
     - [Persistent System Environment Variables](#persistent-system-environment-variables)
+    - [MINGW Requirements](#mingw-requirements)
     - [Scripts](#scripts)
     - [MATLAB MEX](#matlab-mex)
     - [Process FAA Data](#process-faa-data)
@@ -31,8 +32,7 @@ You can confirm `AEM_DIR_CORE` was set in unix by inspecting the output of `env`
 
 ### MINGW Requirements
 
-To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (e.g., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH. This step must be done before running the setup script when using MINGW. 
-The bootstrap.sh script will install xpath and Scalar::Util using Perl's cpan tool.
+To run the code within a MINGW environment, a working installation of Perl is required. If Perl is not already installed in your environment (e.g., when using Git Bash for Windows), you can download [Strawberry Perl](https://strawberryperl.com/), install it and add it to your PATH. This step must be done before running the setup script when using MINGW. The `bootstrap.sh` (see below) script will install `xpath` and` Scalar::Util` using Perl's cpan tool.
 
 ### Scripts
 

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -23,6 +23,18 @@ case "$(uname -s)" in
     # unzip to extract zip archives
     apt install unzip
      ;;
+   MINGW*)
+   # Check if perl is installed
+   if perl -v &>/dev/null
+   then
+      # Install required xpath library
+      echo "Installing xpath..."
+      cpan Scalar::Util
+      cpan XML::XPath
+   else
+      echo "Perl does not seem to be installed. Install Perl, or add Perl to your path."
+   fi
+   ;;
 esac
 
 # git submodules

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -65,6 +65,11 @@ case "$(uname -s)" in
 	# xpath for xml parsing
 	URL_NASR_CURRENT=$(curl -s $URL_NASR_EDITION | xpath -q -e 'string(//productSet/edition/product/@url)')
      ;;
+
+   MINGW*)
+	# MINGW (Windows) does not have xpath installed by default, so use grep and sed. This is somewhat hacky.
+	URL_NASR_CURRENT=$(curl -s $URL_NASR_EDITION | grep -o 'url=".\{0,256\}\.zip' | sed -e 's/^url="//')
+	;;
 esac
 
 # Download file from FAA website

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -67,8 +67,8 @@ case "$(uname -s)" in
      ;;
 
    MINGW*)
-	# MINGW (Windows) does not have xpath installed by default, so use grep and sed. This is somewhat hacky.
-	URL_NASR_CURRENT=$(curl -s $URL_NASR_EDITION | grep -o 'url=".\{0,256\}\.zip' | sed -e 's/^url="//')
+	# MINGW (Windows). Running the command "xpath" does not seem to be guaranteed to work. xpath.bat is, however.
+	URL_NASR_CURRENT=$(curl -s $URL_NASR_EDITION | xpath.bat -q -e 'string(//productSet/edition/product/@url)')
 	;;
 esac
 


### PR DESCRIPTION
Added a case which handles Windows/MINGW within the setup code for downloading FAA NASR data. The script now fully works under a Windows MINGW environment (tested in Windows Git Bash).